### PR TITLE
removed check to determine is Run was active or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ This plugin will issue a token then the following criteria are met:
 
  - The TFE/TFC Token provided has the above mentioned permissions
  - The TFE/TFC Token is a *Service account* token
- - The Run ID provided is in the state "planning" or "applying"
  - The Run ID belongs to the Workspace that is being sent.
  - The Workspace name is in the list of the allowed workspaces for that Role.
  - The Workspace belongs to the TFC/E Organisation configured in the auth backend
+
+ _TFE/C tokens are revoked at the end of a Run_
 
 ### Vault clients / identity
 This authentication backend can be configured to use/create different entities depending on the run status: `planning` or `applying`.

--- a/path_login.go
+++ b/path_login.go
@@ -260,14 +260,7 @@ func (t *tfeLogin) lookup(role *roleStorageEntry, config *tfeAuthConfig) (string
 	}
 
 	msg := fmt.Sprintf("Run status is %s", run.Status)
-	log.L().Info(msg, "info", nil)
-
-	// Run must be active
-	if run.Status != "applying" &&
-		run.Status != "planning" {
-		msg := fmt.Sprintf("Run ID %s status is %s. Expected planning or applying", run.ID, run.Status)
-		return "", fmt.Errorf(msg)
-	}
+	log.L().Debug(msg, "debug", nil)
 
 	// The Run must be related to the specified workspace
 	if run.Workspace.ID != workspace.ID {


### PR DESCRIPTION
TFC/E already revokes the token when the run is not active and this was causing issues with drift detection as per issue #6