### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Create release
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/gitrgoliveira/vault-plugin-auth-tfe/security/code-scanning/1](https://github.com/gitrgoliveira/vault-plugin-auth-tfe/security/code-scanning/1)

To fix the problem, an explicit `permissions` block should be added to the workflow to restrict `GITHUB_TOKEN` permissions to only those required by the job. Since the workflow needs to create release assets (upload to releases—which requires the `contents` write permission), the minimal starting point is to add:

```yaml
permissions:
  contents: write
```

This can be added at the workflow root (before `jobs:`) to apply to all jobs, or inside the specific job if only that job requires it. In this case, we should add it at the root for clarity, as the workflow is very simple and contains only one job. Insert the following lines directly after the workflow `name` and before the `on:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
