### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,6 @@
 name: Build and test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gitrgoliveira/vault-plugin-auth-tfe/security/code-scanning/2](https://github.com/gitrgoliveira/vault-plugin-auth-tfe/security/code-scanning/2)

To fix the problem, add a `permissions: contents: read` block at the root of the workflow file, just below the `name` declaration and before the `on:` section. This will explicitly set the GITHUB_TOKEN permissions for all jobs in the workflow to read-only for repository contents, which is typically the minimum required for build and test steps (and matches the minimal recommendation from the error message). No existing functionality will be changed by this edit. Only the `.github/workflows/build_test.yml` file needs to be changed, specifically lines before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
